### PR TITLE
Perf: fix N+1 queries and duplicate default_scope

### DIFF
--- a/app/models/sla_cache_query.rb
+++ b/app/models/sla_cache_query.rb
@@ -33,8 +33,7 @@ class SlaCacheQuery < Query
     add_available_filter "issue.tracker_id", :type => :list_with_history, :name => l("label_attribute_of_issue",:name => l(:field_tracker)), :values => lambda {trackers.map {|t| [t.name, t.id.to_s]}}
     add_available_filter "issue.status_id", :type => :list_status, :name => l("label_attribute_of_issue", :name => l(:field_status)), :values => lambda {issue_statuses_values}
 
-    if ! project.nil?
-      SlaType.joins(:sla_project_trackers).where("sla_project_trackers.project_id = ?", project.id).select("sla_types.id, sla_types.name").distinct.each { |sla_type|
+    sla_types_for_project.each { |sla_type|
         # SLA Term : Filter ?
         # SLA Spent : Filter ?
         # SLA Remain : Filter
@@ -59,8 +58,7 @@ class SlaCacheQuery < Query
             sql_for_slas_sla_respect_field(field,operator,value,sla_type.id)
           end
         end
-      }
-    end
+    }
 
   end
 
@@ -77,9 +75,7 @@ class SlaCacheQuery < Query
     @available_columns << QueryAssociationColumn.new(:issue, :status, :caption => :field_status, :sortable => "#{IssueStatus.table_name}.position" )
     @available_columns << QueryAssociationColumn.new(:issue, :tracker, :caption => :field_tracker, :sortable => "#{Tracker.table_name}.position" )
     
-    if ! project.nil?
-
-      SlaType.joins(:sla_project_trackers).where("sla_project_trackers.project_id = ?", project.id).select("sla_types.id, sla_types.name").distinct.each { |sla_type|
+    sla_types_for_project.each { |sla_type|
 
         # SLA Term : Column
         name_to_sym = "get_sla_spent_#{sla_type.id}".to_sym
@@ -184,9 +180,7 @@ class SlaCacheQuery < Query
         # end
         @available_columns << get_sla_respect        
 
-      }
-
-    end
+    }
 
     @available_columns
   end
@@ -359,6 +353,18 @@ class SlaCacheQuery < Query
       values << [name.to_s,id.to_s]
     }
     @all_sla_level_values = values
+  end
+
+  private
+
+  def sla_types_for_project
+    return [] if project.nil?
+    @sla_types_for_project ||= SlaType
+      .joins(:sla_project_trackers)
+      .where("sla_project_trackers.project_id = ?", project.id)
+      .select("sla_types.id, sla_types.name")
+      .distinct
+      .to_a
   end
 
 end

--- a/app/models/sla_priority.rb
+++ b/app/models/sla_priority.rb
@@ -62,11 +62,19 @@ class SlaPriority
 
   # TODO : all ( IssuePriority + ScfPriority ) use in SlaLevel for make filter !!!
   def self.all
-    priorities = []
-    SlaLevel.joins(:sla_level_terms).distinct.pluck(:custom_field_id,:sla_priority_id).each { |custom_field_id,sla_priority_id|
-      priorities << SlaPriority.create(custom_field_id).find_by_priority_id(sla_priority_id)
+    pairs = SlaLevel.joins(:sla_level_terms).distinct.pluck(:custom_field_id, :sla_priority_id)
+
+    nil_priority_ids = pairs.select { |cf_id, _| cf_id.nil? }.map(&:last).compact.uniq
+    preloaded = IssuePriority.active.where(id: nil_priority_ids).index_by(&:id)
+
+    pairs.filter_map { |custom_field_id, sla_priority_id|
+      if custom_field_id.nil?
+        priority = preloaded[sla_priority_id]
+        SlaPriorityValue.new({ id: priority.id, name: priority.name }) if priority
+      else
+        SlaPriorityScf.new(custom_field_id).find_by_priority_id(sla_priority_id)
+      end
     }
-    priorities
   end
 
   private

--- a/app/models/sla_project_tracker.rb
+++ b/app/models/sla_project_tracker.rb
@@ -33,8 +33,6 @@ class SlaProjectTracker < ActiveRecord::Base
   extend Redmine::I18n
   include Redmine::SafeAttributes
 
-  default_scope { joins(:tracker) }  
-
   validates_presence_of :project
   validates_presence_of :tracker
   validates_presence_of :sla


### PR DESCRIPTION
- sla_project_tracker: remove redundant first default_scope (tracker already included in the second scope joining sla, tracker and project)
- sla_cache_query: extract repeated SlaType project query into a memoized private method sla_types_for_project, called by both initialize_available_filters and available_columns
- sla_priority: preload IssuePriority records in a single query in self.all instead of one query per pair