### PR TITLE
Fix: replace assert_equal path/current_path with assert_current_path …

### DIFF
--- a/test/system/sla_calendars_test.rb
+++ b/test/system/sla_calendars_test.rb
@@ -71,8 +71,7 @@ class SlaCalendarsHelperSystemTest < ApplicationSlaSystemTestCase
     fill_in 'sla_calendar_name', :with => sla_calendar_name
     click_button l('sla_label.sla_calendar.new')
 
-    # Wait for redirect first — ensures the server has committed the transaction
-    assert_equal sla_calendars_path, current_path
+    assert_current_path sla_calendars_path
     assert_selector 'div#flash_notice', visible: true
 
     # Query DB after redirect is confirmed (server connection has committed)

--- a/test/system/sla_statuses_test.rb
+++ b/test/system/sla_statuses_test.rb
@@ -79,8 +79,7 @@ class SlaStatusesHelperSystemTest < ApplicationSlaSystemTestCase
     # Use click_button with visible label — find('input[name=commit]') unreliable in headless Chrome
     click_button l('sla_label.sla_status.new')
 
-    # Wait for redirect first — ensures the server has committed the transaction
-    assert_equal sla_statuses_path, current_path
+    assert_current_path sla_statuses_path
 
     # Query DB after redirect is confirmed (server connection has committed)
     sla_status = SlaStatus.find_by(

--- a/test/system/sla_types_test.rb
+++ b/test/system/sla_types_test.rb
@@ -74,8 +74,7 @@ class SlaTypesHelperSystemTest < ApplicationSlaSystemTestCase
     # Use click_button with visible label — find('input[name=commit]') unreliable in headless Chrome
     click_button l('sla_label.sla_type.new')
 
-    # Wait for redirect first — ensures the server has committed the transaction
-    assert_equal sla_types_path, current_path
+    assert_current_path sla_types_path
 
     # Query DB after redirect is confirmed (server connection has committed)
     sla_type = SlaType.find_by_name(sla_type_name)


### PR DESCRIPTION
…in system tests

assert_current_path is the idiomatic Capybara helper — it waits for the redirect automatically, making the explicit current_path comparison redundant. Applies to create tests in sla_calendars, sla_statuses and sla_types.