### PR TITLE
Fix: improve error handling in refresh and priority lookup

### DIFF
--- a/app/models/sla_cache_spent.rb
+++ b/app/models/sla_cache_spent.rb
@@ -65,6 +65,8 @@ class SlaCacheSpent < ActiveRecord::Base
   def self.refresh_by_issue_id(issue_id)
     SlaType.all.each do |sla_type|
       ActiveRecord::Base.connection.execute(sanitize_sql(["SELECT sla_get_spent(?,?) ; ", issue_id, sla_type.id]))
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error "[SLA] SlaCacheSpent.refresh_by_issue_id failed for issue ##{issue_id}, sla_type ##{sla_type.id}: #{e.message}"
     end
   end
 

--- a/app/models/sla_priority.rb
+++ b/app/models/sla_priority.rb
@@ -50,9 +50,9 @@ class SlaPriority
 
   # For display one SlaPriority by Priority in Query/Filter
   def find_by_priority_id(priority_id)
-    # TODO : LOG : on ActiveRecord::RecordNotFound si find et nil si find_by
-    priority = IssuePriority.active.find(priority_id)
-    self.create_value(priority.id,priority.name)
+    priority = IssuePriority.active.find_by(id: priority_id)
+    return nil if priority.nil?
+    self.create_value(priority.id, priority.name)
   end  
 
   # For display all SlaPriority in SlaLevel views after self.create ( base on all values of IssuePriority )

--- a/app/models/sla_priority_scf.rb
+++ b/app/models/sla_priority_scf.rb
@@ -32,10 +32,10 @@ class SlaPriorityScf < SlaPriority
 
   # For display one SlaPriorityScf by priority_id in IssueHelper
   def find_by_priority_id(priority_id)
-    # TODO : LOG : on ActiveRecord::RecordNotFound si find et nil si find_by
     return nil if priority_id.nil?
-    priority = @scf.enumerations.active.find(priority_id) 
-    self.create_value(priority.id,priority.name)
+    priority = @scf.enumerations.active.find_by(id: priority_id)
+    return nil if priority.nil?
+    self.create_value(priority.id, priority.name)
   end
   
   # For display all SlaPriority in SlaLevel views after self.create ( base on all values of the CustomField )


### PR DESCRIPTION
- SlaCacheSpent.refresh_by_issue_id: rescue StatementInvalid per iteration so a failure on one sla_type does not interrupt the others; log the error via Rails.logger.error for visibility in production logs
- SlaPriority#find_by_priority_id: replace find with find_by to avoid ActiveRecord::RecordNotFound crash when a priority is inactive or deleted
- SlaPriorityScf#find_by_priority_id: same fix for custom field enumerations