### PR TITLE
Fix: correct duplicate validates_uniqueness_of in SlaSchedule

### DIFF
--- a/app/models/sla_schedule.rb
+++ b/app/models/sla_schedule.rb
@@ -47,7 +47,7 @@ class SlaSchedule < ActiveRecord::Base
     :message => l('sla_label.sla_schedule.exists')
 
   validates_uniqueness_of :sla_calendar_id,
-    :scope => [ :dow, :start_time, :end_time ],
+    :scope => [ :dow, :end_time ],
     :message => l('sla_label.sla_schedule.exists')
 
   validate :sla_schedules_inconsistency


### PR DESCRIPTION
The second uniqueness constraint had scope [:dow, :start_time, :end_time] which was redundant with the first [:dow, :start_time] — anything caught by the second was already caught by the first.

Replace it with scope [:dow, :end_time] to independently enforce that no two schedules end at the same time on the same day for a given calendar, complementing the existing start_time constraint.