### PR TITLE
Fix: replace User.current.admin? with visible? check in context_menu

### DIFF
--- a/app/controllers/sla_caches_controller.rb
+++ b/app/controllers/sla_caches_controller.rb
@@ -159,7 +159,7 @@ class SlaCachesController < ApplicationController
     if @sla_caches.size == 1
       @sla_cache = @sla_caches.first
     end
-    can_show    = User.current.admin?
+    can_show    = @sla_caches.detect { |c| !c.visible? }.nil?
     can_refresh = @sla_caches.detect { |c| !c.visible? }.nil?
     can_delete  = @sla_caches.detect { |c| !c.deletable? }.nil?
     @can = { show: can_show, refresh: can_refresh, delete: can_delete }


### PR DESCRIPTION
can_show was hardcoded to admin-only, bypassing the :view_sla permission. Align it with can_refresh which already uses the same visible? pattern, so any user with :view_sla on the project can access the show action from the context menu — consistent with find_sla_cache which already enforces visible? as the gate.