### PR TITLE
Fix: remove duplicate authorize_global before_action

### DIFF
--- a/app/controllers/sla_levels_controller.rb
+++ b/app/controllers/sla_levels_controller.rb
@@ -36,8 +36,6 @@ class SlaLevelsController < ApplicationController
   before_action :find_sla_level,  only: [:show, :edit, :update, :sla_terms]
   before_action :find_sla_levels, only: [:destroy, :context_menu]
 
-  before_action :authorize_global
-
   helper :sla_levels
   helper :context_menus
 


### PR DESCRIPTION
The callback was declared twice in SlaLevelsController; access control is already enforced once via require_admin + authorize_global.