### PR TITLE
Fix: sanitize sla_cache notice label instead of html_safe

### DIFF
--- a/app/views/sla_caches/index.html.erb
+++ b/app/views/sla_caches/index.html.erb
@@ -8,7 +8,7 @@
   </div>
   <div class="title-sla-settings title-sla_cache">
     <%= title (@project.nil? ? l('sla_label.sla_cache.index') : l(:field_slas) ) %>
-    <p><%= l(:label_sla_notice, url: sla_caches_url).html_safe %></p>
+    <p><%= sanitize(l(:label_sla_notice, url: sla_caches_url)) %></p>
   </div>
   <%= form_tag(_sla_caches_path(@project, nil), method: :get, id: 'query_form') do %>
     <%= render partial: 'queries/query_form' %>

--- a/test/functional/sla_cache_controller_test.rb
+++ b/test/functional/sla_cache_controller_test.rb
@@ -117,6 +117,22 @@ class SlaCachesControllerTest < ApplicationSlaFunctionalsTestCase
     end
   end
 
+  test "should sanitize label_sla_notice and strip unsafe HTML as admin" do
+    @request.session[:user_id] = 1
+    original = I18n.backend.send(:translations).dig(:en, :label_sla_notice)
+    begin
+      I18n.backend.store_translations(:en, label_sla_notice: 'Cache <a href="%{url}">link</a><script>alert(1)</script>')
+      with_settings :default_language => "en" do
+        get :index
+        assert_response :success
+        assert_select 'script', false
+        assert_select 'p a[href]', text: 'link'
+      end
+    ensure
+      I18n.backend.store_translations(:en, label_sla_notice: original)
+    end
+  end
+
   test "should success on get new as admin" do
     @request.session[:user_id] = 1
     assert_raises ActionController::UrlGenerationError do

--- a/test/functional/sla_cache_controller_test.rb
+++ b/test/functional/sla_cache_controller_test.rb
@@ -125,8 +125,10 @@ class SlaCachesControllerTest < ApplicationSlaFunctionalsTestCase
       with_settings :default_language => "en" do
         get :index
         assert_response :success
-        assert_select 'script', false
-        assert_select 'p a[href]', text: 'link'
+        assert_select 'div.title-sla_cache p' do
+          assert_select 'script', false
+          assert_select 'a[href]', text: 'link'
+        end
       end
     ensure
       I18n.backend.store_translations(:en, label_sla_notice: original)


### PR DESCRIPTION
The translated notice contains an interpolated URL and was marked html_safe without sanitization, allowing unescaped HTML through if the locale string is ever altered. Use sanitize instead.