### PR TITLE
Fix: log when SlaCustomField.find/all finds no matching custom field

### DIFF
--- a/app/models/sla_custom_field.rb
+++ b/app/models/sla_custom_field.rb
@@ -28,14 +28,16 @@ class SlaCustomField < IssueCustomField
 
   # TODO : filter on issue with an other method self.find_by_issue ( issue.available_custom_fields.find { |field| field.id == custom_field_id } )
   def self.find(custom_field_id)
-    # TODO : LOG : ERROR : if nil !!!
-    IssueCustomField.find_by(field_format: :enumeration, multiple: :false, is_required:true, id: custom_field_id)
-  end 
+    field = IssueCustomField.find_by(field_format: :enumeration, multiple: :false, is_required:true, id: custom_field_id)
+    Rails.logger.error "SlaCustomField.find: no matching enumeration custom field for id=#{custom_field_id}" if field.nil?
+    field
+  end
 
   # To only list IssueCustomFields of type "enumeration" with single value in SlaLevel#edit
   def self.all
-    # TODO : LOG : NOTICE : if nil 
-    IssueCustomField.where(field_format: :enumeration, multiple: :false, is_required:true)
+    fields = IssueCustomField.where(field_format: :enumeration, multiple: :false, is_required:true)
+    Rails.logger.warn "SlaCustomField.all: no enumeration custom field available" if fields.empty?
+    fields
   end
 
 end

--- a/test/unit/sla_custom_field_test.rb
+++ b/test/unit/sla_custom_field_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Redmine SLA - Redmine's Plugin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+require File.expand_path('../../application_sla_units_test_case', __FILE__)
+
+class SlaCustomFieldTest < ApplicationSlaUnitsTestCase
+
+  def with_captured_log
+    original_logger = Rails.logger
+    io = StringIO.new
+    Rails.logger = Logger.new(io)
+    yield
+    io.string
+  ensure
+    Rails.logger = original_logger
+  end
+
+  test "find logs an error when no matching enumeration custom field exists" do
+    log = with_captured_log { SlaCustomField.find(-1) }
+    assert_nil SlaCustomField.find(-1)
+    assert_match(/no matching enumeration custom field for id=-1/, log)
+  end
+
+  test "all logs a warning when no enumeration custom field is available" do
+    IssueCustomField.where(field_format: :enumeration, multiple: :false, is_required: true).delete_all
+    log = with_captured_log { SlaCustomField.all }
+    assert_match(/no enumeration custom field available/, log)
+  end
+
+end


### PR DESCRIPTION
Previously failed silently, making misconfigured SlaLevel enumeration custom fields hard to diagnose.