### PR TITLE
Fix: sla_cache_spents indexes were created on sla_caches instead

### DIFF
--- a/db/migrate/202111112021015_create_sla_cache_spents.rb
+++ b/db/migrate/202111112021015_create_sla_cache_spents.rb
@@ -55,10 +55,10 @@ class CreateSlaCacheSpents < ActiveRecord::Migration[5.2]
         say "Created table sla_cache_spents"
 
         # Non-unique indexes on project and issue for reporting/filtering
-        add_index :sla_caches, [:project_id],
+        add_index :sla_cache_spents, [:project_id],
                   unique: false,
                   name: 'sla_cache_spents_projects_key'
-        add_index :sla_caches, [:issue_id],
+        add_index :sla_cache_spents, [:issue_id],
                   unique: false,
                   name: 'sla_cache_spents_issues_key'
         say "Created index on table sla_cache_spents"


### PR DESCRIPTION
The two add_index calls after creating sla_cache_spents targeted :sla_caches by mistake (copy-paste from the migration above), leaving sla_cache_spents without its intended project_id/issue_id indexes while adding redundant duplicate indexes on sla_caches.