### PR TITLE
Refactor: rename calendrier SQL alias to calendar

### DIFF
--- a/db/sql_functions/sla_get_level.sql
+++ b/db/sql_functions/sla_get_level.sql
@@ -104,7 +104,7 @@ BEGIN
     "sla_levels"."id" AS "sla_level_id",
 
     -- First matching SLA calendar minute becomes the SLA start date
-    "calendrier"."minutes" AS "start_date",
+    "calendar"."minutes" AS "start_date",
 
     -- Keep original creation date from cache if available
     COALESCE(v_sla_cache.created_on, v_current_timestamp) AS "created_on",
@@ -119,12 +119,12 @@ BEGIN
       v_issue_created_on + INTERVAL '7 days',
       '1 minute'
     ) AS minutes
-  ) AS "calendrier"
+  ) AS "calendar"
 
   INNER JOIN "sla_schedules"
     ON (
-      DATE_PART('dow',"calendrier"."minutes") = "sla_schedules"."dow"
-      AND "calendrier"."minutes"::TIME BETWEEN "sla_schedules"."start_time"
+      DATE_PART('dow',"calendar"."minutes") = "sla_schedules"."dow"
+      AND "calendar"."minutes"::TIME BETWEEN "sla_schedules"."start_time"
                                            AND "sla_schedules"."end_time"
     )
 
@@ -149,7 +149,7 @@ BEGIN
   ) AS "sla_holiday_match"
     ON (
       "sla_holiday_match"."sla_calendar_id" = "sla_schedules"."sla_calendar_id"
-      AND "sla_holiday_match"."date" = "calendrier"."minutes"::DATE
+      AND "sla_holiday_match"."date" = "calendar"."minutes"::DATE
     )
 
   WHERE
@@ -158,7 +158,7 @@ BEGIN
     AND "sla_project_trackers"."tracker_id" = v_issue_tracker_id
 
     -- Exclude declared "non-matching" holidays
-    AND "calendrier"."minutes"::DATE NOT IN (
+    AND "calendar"."minutes"::DATE NOT IN (
       SELECT "sla_holidays"."date"
       FROM "sla_holidays"
       INNER JOIN "sla_calendar_holidays"
@@ -171,10 +171,10 @@ BEGIN
     -- Validate either schedule match OR holiday override
     AND (
       "sla_schedules"."match"
-      OR "sla_holiday_match"."date" = "calendrier"."minutes"::DATE
+      OR "sla_holiday_match"."date" = "calendar"."minutes"::DATE
     )
 
-  ORDER BY "calendrier"."minutes"
+  ORDER BY "calendar"."minutes"
   LIMIT 1 ;
 
   ---------------------------------------------------------------------------

--- a/db/sql_functions/sla_get_level_overlap.sql
+++ b/db/sql_functions/sla_get_level_overlap.sql
@@ -26,12 +26,12 @@ FROM
         NOW() + INTERVAL '7 days',
         '1 minute'
       ) AS minutes
-    ) AS "calendrier"
+    ) AS "calendar"
 
     INNER JOIN "sla_schedules"
       ON (
-        DATE_PART('dow', "calendrier"."minutes") = "sla_schedules"."dow"
-        AND "calendrier"."minutes"::TIME BETWEEN "sla_schedules"."start_time"
+        DATE_PART('dow', "calendar"."minutes") = "sla_schedules"."dow"
+        AND "calendar"."minutes"::TIME BETWEEN "sla_schedules"."start_time"
                                             AND "sla_schedules"."end_time"
       )
 
@@ -52,7 +52,7 @@ WHERE
     AND "sla_schedules"."match"
 
 GROUP BY
-    "calendrier"."minutes"
+    "calendar"."minutes"
 
 HAVING COUNT(*) > 1 ;   -- More than one SLA level applies at the same minute → overlap detected
 

--- a/db/sql_functions/sla_get_spent.sql
+++ b/db/sql_functions/sla_get_spent.sql
@@ -127,11 +127,11 @@ BEGIN
   INNER JOIN
     "sla_view_roll_statuses" ON ( "issues"."id" = "sla_view_roll_statuses"."issue_id" )
   INNER JOIN
-    ( SELECT generate_series ( v_issue_created_on, v_issue_closed_on, '1 minute' ) AS minutes ) AS "calendrier"
-      ON ( "calendrier"."minutes" BETWEEN "sla_view_roll_statuses"."from_status_date" AND "sla_view_roll_statuses"."to_status_date" - INTERVAL '1 minute' )
+    ( SELECT generate_series ( v_issue_created_on, v_issue_closed_on, '1 minute' ) AS minutes ) AS "calendar"
+      ON ( "calendar"."minutes" BETWEEN "sla_view_roll_statuses"."from_status_date" AND "sla_view_roll_statuses"."to_status_date" - INTERVAL '1 minute' )
   INNER JOIN
     "sla_schedules"
-      ON ( DATE_PART('dow',calendrier.minutes) = "sla_schedules"."dow" AND "calendrier"."minutes"::TIME BETWEEN "sla_schedules"."start_time" AND "sla_schedules"."end_time" )
+      ON ( DATE_PART('dow',calendar.minutes) = "sla_schedules"."dow" AND "calendar"."minutes"::TIME BETWEEN "sla_schedules"."start_time" AND "sla_schedules"."end_time" )
   INNER JOIN
     "sla_calendars"
       ON ( "sla_calendars"."id" = "sla_schedules"."sla_calendar_id" )
@@ -151,7 +151,7 @@ BEGIN
     "sla_project_trackers"."tracker_id" = "issues"."tracker_id"
   AND
     -- Exclude dates defined in the holiday calendar
-    DATE_TRUNC('day',"calendrier"."minutes") NOT IN ( 
+    DATE_TRUNC('day',"calendar"."minutes") NOT IN ( 
       SELECT "sla_holidays"."date"
       FROM "sla_holidays"
       INNER JOIN "sla_calendar_holidays"


### PR DESCRIPTION
The stored-procedure functions used a French identifier for a table alias. Pure rename, no behavior change.