### PR TITLE
Chore: translate remaining French test comments/strings to English

### DIFF
--- a/test/files/src_sla/slas.yml
+++ b/test/files/src_sla/slas.yml
@@ -13,10 +13,10 @@ sla_info_std_bug:
   name: SLA Managed Services Standard tracker_production_incident
 sla_info_spe_ask:
   id: 5
-  name: SLA Managed Services Spécific tracker_change_request
+  name: SLA Managed Services Specific tracker_change_request
 sla_info_spe_bug:
   id: 6
-  name: SLA Managed Services Spécific tracker_production_incident
+  name: SLA Managed Services Specific tracker_production_incident
 sla_tma_bug_scf:
   id: 7
   name: SLA TMA tracker_bug_request with Sla Custom Field

--- a/test/functional/sla_cache_controller_test.rb
+++ b/test/functional/sla_cache_controller_test.rb
@@ -26,7 +26,7 @@ class SlaCachesControllerTest < ApplicationSlaFunctionalsTestCase
     User.current = nil
     set_language_if_valid 'en'
     # puts "\n>>> Verification SQL : #{ActiveRecord::Base.connection.execute("SELECT count(*) FROM sla_caches").first}"
-    # # On vérifie si la table est vide OU si c'est le premier passage
+    # # Check if the table is empty OR if this is the first run
     # if !defined?(@@sla_update_done) || !@@sla_update_done || SlaCache.count == 0
     #   RedmineSlaTestBootstrap.ensure_update_sla!
     #   @@sla_update_done = true

--- a/test/functional/sla_level_terms_controller_test.rb
+++ b/test/functional/sla_level_terms_controller_test.rb
@@ -59,7 +59,7 @@ class SlaLevelTermsControllerTest < ApplicationSlaFunctionalsTestCase
       # links to visible issues
       assert_select 'a[href="/sla/level_terms/1"]', :title => "Show"
       # assert_select 'a[href="/sla/level_terms/1/edit"]', :title => "Edit"
-      assert_select_not 'a', { href: "/sla/level_terms/1/edit", title: "Edit" }, "Le lien 'Edit' ne doit pas être présent"
+      assert_select_not 'a', { href: "/sla/level_terms/1/edit", title: "Edit" }, "The 'Edit' link should not be present"
       assert_select 'a[href="/sla/level_terms/1"]', :title => "Delete", :method => "delete"
     end
   end

--- a/test/integration/api_test/sla_cache_spents_test.rb
+++ b/test/integration/api_test/sla_cache_spents_test.rb
@@ -200,7 +200,7 @@ class Redmine::ApiTest::SlaCacheSpentsTest < ApplicationSlaApiTestCase
 
   test "GET /sla/cache_spents.xml should return sla_cache_spents partial for developer" do
     ['developer'].each do |user|
-      # TODO : issue auquel il a accès trier par ordre id asc ???
+      # TODO : issues the user has access to, sorted by ascending id ???
       sla_cache_spent = SlaCacheSpent.where(project: 1).order(:id).first # project-sla-tests-tma
       get "/projects/project-sla-tests-tma/sla/cache_spents.xml?issue.status_id=*&sort=issue",
         headers: credentials(user)

--- a/test/integration/api_test/sla_caches_test.rb
+++ b/test/integration/api_test/sla_caches_test.rb
@@ -201,7 +201,7 @@ class Redmine::ApiTest::SlaCachesTest < ApplicationSlaApiTestCase
 
   test "GET /sla/caches.xml should return sla_caches partial for developer" do
     ['developer'].each do |user|
-      # TODO : issue auquel il a accès trier par ordre id asc ???
+      # TODO : issues the user has access to, sorted by ascending id ???
       sla_cache = SlaCache.where(project: 1).order(:id).first # project-sla-tests-tma
       get "/projects/project-sla-tests-tma/sla/caches.xml?issue.status_id=*&sort=issue",
         headers: credentials(user)

--- a/test/system/sla_calendars_test.rb
+++ b/test/system/sla_calendars_test.rb
@@ -81,7 +81,7 @@ class SlaCalendarsHelperSystemTest < ApplicationSlaSystemTestCase
     # Check flash notice contains the created record id
     assert_selector 'div#flash_notice', visible: true, text: /#{sla_calendar.id}/
 
-    # TODO : vérifier SlaCalendar#show
+    # TODO : check SlaCalendar#show
     # visit "/sla/calendares/#{sla_calendar.id}"
     # compate sla_calendar attributs
 

--- a/test/system/sla_holidays_test.rb
+++ b/test/system/sla_holidays_test.rb
@@ -86,7 +86,7 @@ class SlaHolidaysHelperSystemTest < ApplicationSlaSystemTestCase
     # Check flash notice contains the created record id
     assert_selector 'div#flash_notice', visible: true, text: /#{sla_holiday.id}/
 
-    # TODO : vérifier SlaHoliday#show
+    # TODO : check SlaHoliday#show
     # visit "/sla/holidayes/#{sla_holiday.id}"
     # compate sla_holiday attributs
 

--- a/test/system/sla_level_terms_test.rb
+++ b/test/system/sla_level_terms_test.rb
@@ -81,7 +81,7 @@ class SlaLevelTermsHelperSystemTest < ApplicationSlaSystemTestCase
     # Query DB after redirect is confirmed (server connection has committed)
     sla_level_term = SlaLevelTerm.find_by(sla_level_id: sla_level.id, sla_type_id: 1, sla_priority_id: 1)
 
-    # TODO : vérifier SlaLevelTerm#show
+    # TODO : check SlaLevelTerm#show
     # visit "/sla/level_termes/#{sla_level_term.id}"
     # compate sla_level_term attributs
 

--- a/test/unit/sla_level_test.rb
+++ b/test/unit/sla_level_test.rb
@@ -76,7 +76,7 @@ class SlaLevelTest < ApplicationSlaUnitsTestCase
           #sla_cache_spent = SlaCacheSpent.find_or_new(sla_cache.id,sla_type_id)
           #sla_type_spent_issue = sla_cache_spent[:spent]
           sla_spent = issue.get_sla_spent(sla_type_id)
-          # TODO : SlaLog : si valeur nulle
+          # TODO : SlaLog : if value is nil
           next if ( sla_spent.nil? )
 
           # puts "- - - > found > spent = #{sla_type_spent_issue} for term = #{sla_type_term_issue}"


### PR DESCRIPTION
## Summary
- Translates leftover French comments/TODOs and one assertion message across the test suite to English
- Fixes a fixture name typo ("Spécific" -> "Specific") in test/files/src_sla/slas.yml
- No behavior change; comments/strings only

## Test plan
- [ ] Syntax-checked with `ruby -c` on all edited files
- [ ] `slas.yml` fixture validated with YAML.load_file