### PR TITLE
Optimize sla_get_level/sla_get_spent holiday exclusion (PostgreSQL + MySQL)

### DIFF
--- a/db/sql_functions/mysql/sla_get_level.sql
+++ b/db/sql_functions/mysql/sla_get_level.sql
@@ -126,21 +126,29 @@ BEGIN
           sla_holiday_match.sla_calendar_id = sla_schedules.sla_calendar_id
           AND sla_holiday_match.`date` = DATE(calendar.minutes)
         )
+      -- Every (calendar, date) excluded by a non-matching holiday, computed
+      -- once instead of as a correlated NOT IN re-scanned per candidate
+      -- minute (~10,000 rows) -- that correlated subquery was the dominant
+      -- cost of this query (see the PostgreSQL port for the full writeup).
+      LEFT JOIN
+        (
+          SELECT DISTINCT sla_calendar_holidays.sla_calendar_id AS sla_calendar_id, sla_holidays.`date` AS `date`
+          FROM sla_holidays
+          INNER JOIN sla_calendar_holidays
+            ON (sla_holidays.id = sla_calendar_holidays.sla_holiday_id)
+          WHERE NOT sla_calendar_holidays.`match`
+        ) AS excluded_holidays
+        ON (
+          excluded_holidays.sla_calendar_id = sla_calendars.id
+          AND excluded_holidays.`date` = DATE(calendar.minutes)
+        )
     WHERE
       -- Must match project and tracker SLA configuration
       sla_project_trackers.project_id = v_issue_project_id
       AND sla_project_trackers.tracker_id = v_issue_tracker_id
 
-      -- Exclude declared "non-matching" holidays
-      AND DATE(calendar.minutes) NOT IN (
-        SELECT sla_holidays.`date`
-        FROM sla_holidays
-        INNER JOIN sla_calendar_holidays
-          ON (sla_holidays.id = sla_calendar_holidays.sla_holiday_id)
-        WHERE
-          sla_calendar_holidays.sla_calendar_id = sla_calendars.id
-          AND NOT sla_calendar_holidays.`match`
-      )
+      -- Exclude declared "non-matching" holidays (anti-join: no match found above)
+      AND excluded_holidays.`date` IS NULL
 
       -- Validate either schedule match OR holiday override
       AND (

--- a/db/sql_functions/mysql/sla_get_spent.sql
+++ b/db/sql_functions/mysql/sla_get_spent.sql
@@ -214,6 +214,16 @@ BEGIN
         SELECT 0 AS n
         UNION ALL
         SELECT n + 1 FROM seq WHERE n < v_window_days
+    ),
+    excluded_holidays AS (
+        -- Every (calendar, date) pair excluded by a non-matching holiday,
+        -- materialized once instead of re-evaluated as a correlated NOT IN
+        -- subquery per (day, schedule, status-interval) row below.
+        SELECT DISTINCT sla_calendar_holidays.sla_calendar_id AS sla_calendar_id, sla_holidays.`date` AS `date`
+        FROM sla_holidays
+        INNER JOIN sla_calendar_holidays
+          ON (sla_calendar_holidays.sla_holiday_id = sla_holidays.id)
+        WHERE NOT sla_calendar_holidays.`match`
     )
     SELECT COALESCE(SUM(
       GREATEST(0, TIMESTAMPDIFF(MINUTE,
@@ -240,6 +250,11 @@ BEGIN
       ON (sla_levels.sla_calendar_id = sla_calendars.id AND sla_levels.id = v_cache_sla_level_id)
     INNER JOIN sla_project_trackers
       ON (sla_project_trackers.sla_id = sla_levels.sla_id)
+    LEFT JOIN excluded_holidays
+      ON (
+        excluded_holidays.sla_calendar_id = sla_calendars.id
+        AND excluded_holidays.`date` = calendar.day_date
+      )
     WHERE
       issue_roll_statuses.from_status_id IN (
         SELECT DISTINCT sla_statuses.status_id FROM sla_statuses WHERE sla_statuses.sla_type_id = p_sla_type_id
@@ -249,15 +264,8 @@ BEGIN
     AND
       sla_project_trackers.tracker_id = v_issue_tracker_id
     AND
-      -- Exclude dates defined in the holiday calendar
-      calendar.day_date NOT IN (
-        SELECT sla_holidays.`date`
-        FROM sla_holidays
-        INNER JOIN sla_calendar_holidays
-          ON (sla_calendar_holidays.sla_holiday_id = sla_holidays.id)
-        WHERE sla_calendar_holidays.sla_calendar_id = sla_calendars.id
-          AND NOT sla_calendar_holidays.`match`
-      )
+      -- Exclude dates defined in the holiday calendar (anti-join: no match found above)
+      excluded_holidays.`date` IS NULL
     AND
       -- Only keep (day, schedule, status-interval) triples that actually overlap
       GREATEST(issue_roll_statuses.from_status_date, TIMESTAMP(calendar.day_date, sla_schedules.start_time), v_window_start)

--- a/db/sql_functions/postgresql/sla_get_level.sql
+++ b/db/sql_functions/postgresql/sla_get_level.sql
@@ -95,7 +95,27 @@ BEGIN
   -- then matches each timestamp against SLA calendars, schedules, holidays,
   -- and project-tracker SLA configuration, to find the first valid SLA start date.
   ---------------------------------------------------------------------------
-  SELECT DISTINCT
+  WITH "excluded_holidays" AS (
+    -- Every (calendar, date) pair excluded by a non-matching holiday.
+    -- Materialized once up front instead of re-evaluated as a correlated
+    -- subquery per candidate minute (see the anti-join below): with 7 days
+    -- of minute granularity there are ~10,000 candidate rows, and a
+    -- correlated NOT IN forced a full per-row re-scan of sla_holidays for
+    -- each of them -- the dominant cost of this query. A single
+    -- pre-computed set turns that into one ordinary hash join.
+    SELECT DISTINCT
+      "sla_calendar_holidays"."sla_calendar_id",
+      "sla_holidays"."date"
+    FROM "sla_holidays"
+    INNER JOIN "sla_calendar_holidays"
+      ON ( "sla_holidays"."id" = "sla_calendar_holidays"."sla_holiday_id" )
+    WHERE NOT "sla_calendar_holidays"."match"
+  )
+  -- No DISTINCT: LIMIT 1 already caps the result to a single row regardless,
+  -- and the MySQL port of this same query (already validated end-to-end
+  -- against the real test suite) never needed one either -- it was pure
+  -- overhead forcing a full dedup pass before the LIMIT could apply.
+  SELECT
     -- Cache record to be written (cache ID is determined at INSERT time)
     NULL::bigint AS "id",
     "v_issue_project_id" AS "project_id",
@@ -152,21 +172,19 @@ BEGIN
       AND "sla_holiday_match"."date" = "calendar"."minutes"::DATE
     )
 
+  LEFT JOIN "excluded_holidays"
+    ON (
+      "excluded_holidays"."sla_calendar_id" = "sla_calendars"."id"
+      AND "excluded_holidays"."date" = "calendar"."minutes"::DATE
+    )
+
   WHERE
     -- Must match project and tracker SLA configuration
     "sla_project_trackers"."project_id" = v_issue_project_id
     AND "sla_project_trackers"."tracker_id" = v_issue_tracker_id
 
-    -- Exclude declared "non-matching" holidays
-    AND "calendar"."minutes"::DATE NOT IN (
-      SELECT "sla_holidays"."date"
-      FROM "sla_holidays"
-      INNER JOIN "sla_calendar_holidays"
-        ON ( "sla_holidays"."id" = "sla_calendar_holidays"."sla_holiday_id" )
-      WHERE
-        "sla_calendar_holidays"."sla_calendar_id" = "sla_calendars"."id"
-        AND NOT "sla_calendar_holidays"."match"
-    )
+    -- Exclude declared "non-matching" holidays (anti-join: no match found above)
+    AND "excluded_holidays"."date" IS NULL
 
     -- Validate either schedule match OR holiday override
     AND (

--- a/db/sql_functions/postgresql/sla_get_spent.sql
+++ b/db/sql_functions/postgresql/sla_get_spent.sql
@@ -116,6 +116,18 @@ BEGIN
   --    with the issue's status-history intervals (roll_statuses) and the
   --    calculation window itself, and sum the resulting minute counts.
   -- 3. Exclude public holidays.
+  WITH "excluded_holidays" AS (
+    -- Every (calendar, date) pair excluded by a non-matching holiday,
+    -- materialized once instead of re-evaluated as a correlated NOT IN
+    -- subquery per (day, schedule, status-interval) row below.
+    SELECT DISTINCT
+      "sla_calendar_holidays"."sla_calendar_id",
+      "sla_holidays"."date"
+    FROM "sla_holidays"
+    INNER JOIN "sla_calendar_holidays"
+      ON ( "sla_calendar_holidays"."sla_holiday_id" = "sla_holidays"."id" )
+    WHERE NOT "sla_calendar_holidays"."match"
+  )
   SELECT DISTINCT
     NULL::integer AS "id",
     COALESCE( v_sla_spent."sla_cache_id", v_sla_cache."id" ) AS "sla_cache_id",
@@ -160,6 +172,12 @@ BEGIN
   INNER JOIN
     "sla_project_trackers"
       ON ( "sla_project_trackers"."sla_id" = "sla_levels"."sla_id" )
+  LEFT JOIN
+    "excluded_holidays"
+      ON (
+        "excluded_holidays"."sla_calendar_id" = "sla_calendars"."id"
+        AND "excluded_holidays"."date" = "calendar"."day_date"::date
+      )
   WHERE
     "issues"."id" = p_issue_id
   AND
@@ -169,15 +187,8 @@ BEGIN
   AND
     "sla_project_trackers"."tracker_id" = "issues"."tracker_id"
   AND
-    -- Exclude dates defined in the holiday calendar
-    "calendar"."day_date"::date NOT IN (
-      SELECT "sla_holidays"."date"
-      FROM "sla_holidays"
-      INNER JOIN "sla_calendar_holidays"
-      ON ( "sla_calendar_holidays"."sla_holiday_id" = "sla_holidays"."id" )
-      WHERE "sla_calendar_holidays"."sla_calendar_id" = "sla_calendars"."id"
-      AND NOT "sla_calendar_holidays"."match"
-    )
+    -- Exclude dates defined in the holiday calendar (anti-join: no match found above)
+    "excluded_holidays"."date" IS NULL
   AND
     -- Only keep (day, schedule, status-interval) triples that actually overlap
     GREATEST(


### PR DESCRIPTION
## Summary
- Both `sla_get_level` and `sla_get_spent` filtered non-matching holidays via a correlated `NOT IN` subquery re-evaluated once per candidate row (~10,000 rows for `sla_get_level`'s minute-by-minute 7-day window). Replaced with a CTE computing the exclusion set once, joined via a `LEFT JOIN` + `IS NULL` anti-join.
- Dropped the redundant `DISTINCT` in PostgreSQL's `sla_get_level`: `LIMIT 1` already caps the result to one row, and the MySQL port of the same query never needed one.
- Applied to both PostgreSQL and MySQL versions of both functions for consistency.

## Benchmark (500-issue sample, synthetic 20k-issue/57k-journal dataset, persistent connection, cold cache)
| | Before | After |
|---|---|---|
| PostgreSQL `sla_get_level` | 48.1ms | **5.6ms** |
| PostgreSQL `sla_get_spent` | 10.6ms | **3.9ms** |
| MySQL `sla_get_level` | 20.9ms | 19.6ms |
| MySQL `sla_get_spent` | 6.5ms | 6.3ms |

## Test plan
- [x] Full suite (unit/functional/integration/system/documentation) run against real PostgreSQL and MySQL
- [x] Documentation suite (spent/term values checked against the hand-verified reference CSV) unaffected: **60 runs, 511 assertions, 0 failures** on both engines
- [x] Multi-level SLA overlap scenario + holiday-override edge case manually verified to produce identical results before/after the rewrite
- [x] The one unit-test failure observed during validation (`SlaLevelTest`) was confirmed **pre-existing and unrelated**: reproduces identically against the unmodified `sla_get_spent.sql`
- [ ] Other functional/integration failures observed during validation are the two already-documented, unrelated issues from the MySQL/MariaDB support PR (#52): stale `total_count` on the `/sla/slas` API listing, and `SlaCache` bootstrap ordering flakiness — not touched by this PR