### PR TITLE
Downgrade SLA query trace logs from error to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.1.3 (Stable - Redmine 6.x)
+
+### Fixed
+
+-   Fix: `IssueQueryPatch#available_filters_with_sla_issue` logged three
+    routine execution traces at `error` level, polluting production logs
+    with non-error noise every time the issue list filters are built.
+    Downgraded to `debug`.
+
+------------------------------------------------------------------------
+
 ## 2.1.2 (Stable - Redmine 6.x)
 
 ### Fixed

--- a/lib/redmine_sla/patches/issue_query_patch.rb
+++ b/lib/redmine_sla/patches/issue_query_patch.rb
@@ -133,7 +133,7 @@ module RedmineSla
       #   - adds SLA respect filters + columns per SLA type
       def available_filters_with_sla_issue
         # Debug tracing
-        Rails.logger.error "--- REDMINE_SLA TRACE: available_filters_with_sla_issue CALL ---"
+        Rails.logger.debug "--- REDMINE_SLA TRACE: available_filters_with_sla_issue CALL ---"
 
         is_filters_blank = @available_filters.blank?
         is_module_enabled = project&.module_enabled?(:sla)
@@ -244,11 +244,11 @@ module RedmineSla
             end
 
           else
-            Rails.logger.error "--- REDMINE_SLA TRACE: 'sla_types' table missing, skipping SLA columns ---"
+            Rails.logger.debug "--- REDMINE_SLA TRACE: 'sla_types' table missing, skipping SLA columns ---"
           end
 
         else
-          Rails.logger.error "--- REDMINE_SLA TRACE: EXIT: filters not initialized. ---"
+          Rails.logger.debug "--- REDMINE_SLA TRACE: EXIT: filters not initialized. ---"
           return available_filters_without_sla_issue
         end
 

--- a/lib/redmine_sla/version.rb
+++ b/lib/redmine_sla/version.rb
@@ -25,5 +25,5 @@
 module RedmineSla
   # Current plugin version.
   # This is the value displayed in Redmine's plugin administration screen.
-  Version = '2.1.2'.freeze
+  Version = '2.1.3'.freeze
 end


### PR DESCRIPTION
## Summary
- `IssueQueryPatch#available_filters_with_sla_issue` logged three routine execution traces at `error` level, polluting production logs with non-error noise every time the issue list filters are built.
- Switched them to `debug`, matching what they actually are.

## Test plan
- [x] Full plugin test suite (unit/functional/integration/system/documentation) passes unchanged.