### PR TITLE
Use delete_all instead of destroy_all for SLA cache purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.1.4 (Stable - Redmine 6.x)
+
+### Performance
+
+-   Perf: `SlaCache.purge`/`SlaCacheSpent.purge` (project-scoped branch) and
+    `SlaCache.destroy_by_issue_id` now use `delete_all` instead of
+    `destroy_all` — neither model has callbacks, and
+    `sla_cache_spents.sla_cache_id` has an `ON DELETE CASCADE` foreign key,
+    so a single `DELETE` statement is equivalent and considerably faster on
+    large volumes.
+
+------------------------------------------------------------------------
+
 ## 2.1.3 (Stable - Redmine 6.x)
 
 ### Fixed

--- a/app/models/sla_cache.rb
+++ b/app/models/sla_cache.rb
@@ -75,12 +75,12 @@ class SlaCache < ActiveRecord::Base
     if ( project.nil? )
       ActiveRecord::Base.connection.execute("TRUNCATE sla_caches CASCADE ; ")
     else
-      SlaCache.where(project: project.id).destroy_all
+      SlaCache.where(project: project.id).delete_all
     end
   end
     
   def self.destroy_by_issue_id(issue_id)
-    SlaCache.where(issue: issue_id).destroy_all
+    SlaCache.where(issue: issue_id).delete_all
   end              
 
   # For SlaCacheQuery#GroupBy

--- a/app/models/sla_cache_spent.rb
+++ b/app/models/sla_cache_spent.rb
@@ -79,8 +79,8 @@ class SlaCacheSpent < ActiveRecord::Base
     if ( project.nil? )
       ActiveRecord::Base.connection.execute("TRUNCATE sla_cache_spents CASCADE ; ")
     else
-      SlaCacheSpent.where(project: project.id).destroy_all
+      SlaCacheSpent.where(project: project.id).delete_all
     end
-  end  
+  end
     
 end

--- a/lib/redmine_sla/version.rb
+++ b/lib/redmine_sla/version.rb
@@ -25,5 +25,5 @@
 module RedmineSla
   # Current plugin version.
   # This is the value displayed in Redmine's plugin administration screen.
-  Version = '2.1.3'.freeze
+  Version = '2.1.4'.freeze
 end


### PR DESCRIPTION
## Summary
- `SlaCache.purge`/`SlaCacheSpent.purge` (project-scoped branch) and `SlaCache.destroy_by_issue_id` used `destroy_all`, which instantiates and destroys every matching row one by one.
- Switched to `delete_all`: neither model has callbacks, and `sla_cache_spents.sla_cache_id` has an `ON DELETE CASCADE` foreign key, so a single `DELETE` statement is equivalent and considerably faster on large volumes.

## Test plan
- [x] Full plugin test suite (unit/functional/integration/system/documentation) passes unchanged.