### PR TITLE
Fix SLA gauge rendering: bar-rounded circle glitch and pie-flat legibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.1.5 (Stable - Redmine 6.x)
+
+### Fixed
+
+-   Fix: `bar - rounded` gauge fill rendered as a near-perfect circle
+    around ~20% (its 12px `border-radius` and the filled width both
+    landing close to half the bar's height at that point) — lowered the
+    radius to 8px so it stays visibly rounded without ever fully closing
+    into a circle. Added a 12px `min-width` floor so the fill stays a
+    visible rounded pill below ~16px, and hides the fill outright under
+    4% instead of showing a disproportionate sliver.
+-   Fix: `pie - flat` ring widened from 6px to 10px (disc grown from 56px
+    to 64px to compensate) for legibility — the narrower ring cramped the
+    label, most noticeably the longer `>100%` text.
+
+------------------------------------------------------------------------
+
 ## 2.1.4 (Stable - Redmine 6.x)
 
 ### Performance

--- a/app/helpers/sla_issues_helper.rb
+++ b/app/helpers/sla_issues_helper.rb
@@ -51,6 +51,10 @@ module SlaIssuesHelper
         css_type = "sla_pie_flat_base sla_pie_plain"
       when "bar - rounded"
         css_type = "sla_bar sla_bar_rounded"
+        # Below 5px (4% of the 125px bar), even the floored min-width would
+        # force a visible fill out of a value that's really "barely started" --
+        # clearer to show no fill at all than an arbitrarily-sized nub.
+        css_type += " sla_bar_no_fill" if percent < 4
       else
         css_type = "sla_bar sla_bar_square"
     end

--- a/assets/stylesheets/redmine_sla.css
+++ b/assets/stylesheets/redmine_sla.css
@@ -41,10 +41,32 @@
   .sla_bar_square { border-radius: 5%; }
   .sla_bar_square::after { border-radius: 5%; }
   .sla_bar_rounded {
-    border-radius: 12px;
+    /* Kept well under half the bar's 25px height: at 12px (~half), a fill
+       whose width happens to land near 25px (e.g. ~20% of the 125px bar)
+       turns into a near-perfect circle -- reading as "done" instead of a
+       partial fill. 8px still looks rounded at any width without ever
+       fully closing into a circle/pill at some unlucky percentage. */
+    border-radius: 8px;
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.15);
   }
-  .sla_bar_rounded::after { border-radius: 12px; }
+  .sla_bar_rounded::after {
+    border-radius: 8px;
+    /* Below ~2x the radius, the browser clamps the corner curvature down
+       to fit the box, so at very low percentages (a couple of px wide)
+       the curve shrinks to sub-pixel and the fill reads as a straight
+       edge instead of rounded. A floor on the width keeps it a visible
+       small pill once it's shown at all (see .sla_bar_no_fill below for
+       the even-smaller values where nothing is shown instead). */
+    min-width: 12px;
+  }
+  /* Below 5px (4% of the 125px bar) the sla_display helper adds this
+     class instead of letting min-width force a fill: at that point the
+     floor above would be pure invention relative to the real value, so
+     showing no fill at all reads better than an arbitrary-looking nub.
+     Two classes (not one) so this reliably outranks .sla_bar:after's
+     `display: block` below regardless of source order -- same specificity
+     there would make the later rule in the file win. */
+  .sla_bar.sla_bar_no_fill::after { display: none; }
 
   .sla_bar::before,
   .sla_bar::after {
@@ -152,6 +174,16 @@
      out for the label. So the ring is drawn on a ::before instead (same
      technique as sla_pie_modern) and mask cuts the center hole, leaving a
      real see-through ring with the label floating over it. */
+  .sla_pie_flat {
+    /* Wider ring than the shared --b:6px default (only affects this
+       variant -- sla_pie_plain doesn't use --b, it's a solid disc). */
+    --b: 10px;
+    /* Grow the whole disc to compensate: the ring eats into the center
+       hole (hole radius = w/2 - b), so widening the ring alone shrank the
+       hole from ~44px to ~36px, cramping longer labels like ">100%".
+       64px restores roughly the original hole size at the new thickness. */
+    --w: 64px;
+  }
   .sla_pie_flat::before {
     content: "";
     position: absolute;

--- a/lib/redmine_sla/version.rb
+++ b/lib/redmine_sla/version.rb
@@ -25,5 +25,5 @@
 module RedmineSla
   # Current plugin version.
   # This is the value displayed in Redmine's plugin administration screen.
-  Version = '2.1.4'.freeze
+  Version = '2.1.5'.freeze
 end


### PR DESCRIPTION
## Summary
**bar - rounded**
- The fill's `border-radius` was 12px, about half the bar's 25px height. Whenever the filled width happened to land near 25px too (~20% of the 125px bar), radius and width both being ~half the box turned the fill into a near-perfect circle -- reading as "done" instead of a partial fill. Lowered to 8px, which stays visibly rounded without ever fully closing into a circle at any percentage.
- Below ~16px wide, the browser clamps that corner radius down to fit the box, shrinking to sub-pixel and making very small percentages read as a flat edge instead of rounded. Added a 12px `min-width` floor so the fill stays a visible rounded pill once shown.
- Below 5px (under 4%), even that floor would show a fill sized well out of proportion to the real value. Below that threshold, `sla_display` now adds a modifier class that hides the fill outright instead.

**pie - flat**
- Widened the ring from 6px to 10px, and grew the overall disc from 56px to 64px to compensate (ring width eats into the center hole, hole radius = `w/2 - b`) -- widening the ring alone had cramped the label, most noticeably the longer `>100%` text.

## Test plan
- [x] Full plugin test suite (unit/functional/integration/system/documentation) passes unchanged.
- [x] Verified visually in an isolated headless-Chromium render across the 0%/1%/3%/4%/6%/11%/20%/50%/80%/>100% range for both styles.
- [x] Verified live against a running instance.