### PR TITLE
Report SLA calculation timings in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Testing
 
 -   Report real `sla_get_level` and `sla_get_spent` calculation durations
-    (`min`, `max` and `avg`) during the unit suite, labelled by database
-    engine, without imposing environment-dependent performance thresholds.
+    (`min`, `median`, `p95`, `max` and `avg`) during the unit suite, labelled
+    by database engine, without imposing environment-dependent performance
+    thresholds.
 
 ------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Testing
 
--   Report real `sla_get_level` and `sla_get_spent` calculation durations
-    (`min`, `median`, `p95`, `max` and `avg`) during the unit suite, labelled
-    by database engine, without imposing environment-dependent performance
-    thresholds.
+-   Report real `sla_get_level` forced/cached and `sla_get_spent` calculation
+    durations (`min`, `median`, `p95`, `max` and `avg`) during the unit suite,
+    labelled by database engine, without imposing environment-dependent
+    performance thresholds.
 
 ------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Testing
+
+-   Report real `sla_get_level` and `sla_get_spent` calculation durations
+    (`min`, `max` and `avg`) during the unit suite, labelled by database
+    engine, without imposing environment-dependent performance thresholds.
+
+------------------------------------------------------------------------
+
 ## 3.0.0
 
 ### Added

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -16,12 +16,13 @@ Now, you can run the units tests: `bundle exec rake redmine:plugins:test:units N
 
 > **_NOTE:_** Unit tests are such as controller actions or SLA calculations.
 
-The unit suite also runs the real `sla_get_level` and `sla_get_spent`
-functions against every SLA issue/type in the test fixtures. It prints an
-informational line for each function with the database name, call count and
-`min`/`median`/`p95`/`max`/`avg` duration in milliseconds. Timings deliberately
-have no pass or fail threshold because they depend on the database host and CI
-load; correctness assertions remain mandatory.
+The unit suite also runs the real `sla_get_level` (forced recalculation and
+cached lookup) and `sla_get_spent` functions against every SLA issue/type in
+the test fixtures. It prints an informational line for each path with the
+database name, call count and `min`/`median`/`p95`/`max`/`avg` duration in
+milliseconds. Timings deliberately have no pass or fail threshold because they
+depend on the database host and CI load; correctness assertions remain
+mandatory.
 
 ### Functionals
 But also functionals tests: `bundle exec rake redmine:plugins:test:functionals NAME=redmine_sla RAILS_ENV=test TESTOPTS="-v -w -b" --trace`

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -16,6 +16,13 @@ Now, you can run the units tests: `bundle exec rake redmine:plugins:test:units N
 
 > **_NOTE:_** Unit tests are such as controller actions or SLA calculations.
 
+The unit suite also runs the real `sla_get_level` and `sla_get_spent`
+functions against every SLA issue/type in the test fixtures. It prints an
+informational line for each function with the database name, call count and
+`min`/`max`/`avg` duration in milliseconds. Timings deliberately have no pass
+or fail threshold because they depend on the database host and CI load;
+correctness assertions remain mandatory.
+
 ### Functionals
 But also functionals tests: `bundle exec rake redmine:plugins:test:functionals NAME=redmine_sla RAILS_ENV=test TESTOPTS="-v -w -b" --trace`
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -19,9 +19,9 @@ Now, you can run the units tests: `bundle exec rake redmine:plugins:test:units N
 The unit suite also runs the real `sla_get_level` and `sla_get_spent`
 functions against every SLA issue/type in the test fixtures. It prints an
 informational line for each function with the database name, call count and
-`min`/`max`/`avg` duration in milliseconds. Timings deliberately have no pass
-or fail threshold because they depend on the database host and CI load;
-correctness assertions remain mandatory.
+`min`/`median`/`p95`/`max`/`avg` duration in milliseconds. Timings deliberately
+have no pass or fail threshold because they depend on the database host and CI
+load; correctness assertions remain mandatory.
 
 ### Functionals
 But also functionals tests: `bundle exec rake redmine:plugins:test:functionals NAME=redmine_sla RAILS_ENV=test TESTOPTS="-v -w -b" --trace`

--- a/test/unit/sla_calculation_performance_test.rb
+++ b/test/unit/sla_calculation_performance_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Reports database SLA calculation timings while exercising the same stored
+# functions used by the application. These measurements are informational:
+# correctness assertions fail the test, but machine-dependent timings do not.
+
+require File.expand_path('../../application_sla_units_test_case', __FILE__)
+
+class SlaCalculationPerformanceTest < ApplicationSlaUnitsTestCase
+  test 'report sla_get_level and sla_get_spent timings' do
+    connection = ActiveRecord::Base.connection
+    issue_ids = SlaCache.unscoped.order(:issue_id).pluck(:issue_id)
+    sla_type_ids = SlaType.order(:id).pluck(:id)
+
+    assert_not_empty issue_ids, 'No SLA issue is available for the benchmark'
+    assert_not_empty sla_type_ids, 'No SLA type is available for the benchmark'
+
+    RedmineSla::DbDialect.ensure_recursion_depth!
+
+    level_timings = issue_ids.map do |issue_id|
+      measure_ms do
+        connection.execute(SlaCache.sanitize_sql(["SELECT sla_get_level(?, true);", issue_id]))
+      end
+    end
+
+    spent_timings = issue_ids.product(sla_type_ids).map do |issue_id, sla_type_id|
+      # sla_get_spent has no force flag: remove only this cached result before
+      # timing so the function performs the real calculation on every call.
+      SlaCacheSpent.unscoped.where(issue_id: issue_id, sla_type_id: sla_type_id).delete_all
+      measure_ms do
+        connection.execute(
+          SlaCacheSpent.sanitize_sql(["SELECT sla_get_spent(?, ?);", issue_id, sla_type_id])
+        )
+      end
+    end
+
+    assert_equal issue_ids.size, level_timings.size
+    assert_equal issue_ids.size * sla_type_ids.size, spent_timings.size
+
+    report_timings('sla_get_level', level_timings)
+    report_timings('sla_get_spent', spent_timings)
+  end
+
+  private
+
+  def measure_ms
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1_000
+  end
+
+  def report_timings(operation, timings)
+    average = timings.sum / timings.size
+    puts format(
+      '[SLA timing] database=%<database>s operation=%<operation>s calls=%<calls>d ' \
+      'min=%<min>.3fms max=%<max>.3fms avg=%<average>.3fms',
+      database: database_name,
+      operation: operation,
+      calls: timings.size,
+      min: timings.min,
+      max: timings.max,
+      average: average
+    )
+  end
+
+  def database_name
+    return ActiveRecord::Base.connection.adapter_name unless RedmineSla::DbDialect.adapter == :mysql
+
+    version = ActiveRecord::Base.connection.select_value('SELECT VERSION()').to_s
+    version.include?('MariaDB') ? 'MariaDB' : 'MySQL'
+  end
+end

--- a/test/unit/sla_calculation_performance_test.rb
+++ b/test/unit/sla_calculation_performance_test.rb
@@ -17,9 +17,15 @@ class SlaCalculationPerformanceTest < ApplicationSlaUnitsTestCase
 
     RedmineSla::DbDialect.ensure_recursion_depth!
 
-    level_timings = issue_ids.map do |issue_id|
+    forced_level_timings = issue_ids.map do |issue_id|
       measure_ms do
         connection.execute(SlaCache.sanitize_sql(["SELECT sla_get_level(?, true);", issue_id]))
+      end
+    end
+
+    cached_level_timings = issue_ids.map do |issue_id|
+      measure_ms do
+        connection.execute(SlaCache.sanitize_sql(["SELECT sla_get_level(?, false);", issue_id]))
       end
     end
 
@@ -34,10 +40,12 @@ class SlaCalculationPerformanceTest < ApplicationSlaUnitsTestCase
       end
     end
 
-    assert_equal issue_ids.size, level_timings.size
+    assert_equal issue_ids.size, forced_level_timings.size
+    assert_equal issue_ids.size, cached_level_timings.size
     assert_equal issue_ids.size * sla_type_ids.size, spent_timings.size
 
-    report_timings('sla_get_level', level_timings)
+    report_timings('sla_get_level_forced', forced_level_timings)
+    report_timings('sla_get_level_cached', cached_level_timings)
     report_timings('sla_get_spent', spent_timings)
   end
 

--- a/test/unit/sla_calculation_performance_test.rb
+++ b/test/unit/sla_calculation_performance_test.rb
@@ -51,16 +51,24 @@ class SlaCalculationPerformanceTest < ApplicationSlaUnitsTestCase
 
   def report_timings(operation, timings)
     average = timings.sum / timings.size
+    sorted = timings.sort
     puts format(
       '[SLA timing] database=%<database>s operation=%<operation>s calls=%<calls>d ' \
-      'min=%<min>.3fms max=%<max>.3fms avg=%<average>.3fms',
+      'min=%<min>.3fms median=%<median>.3fms p95=%<p95>.3fms ' \
+      'max=%<max>.3fms avg=%<average>.3fms',
       database: database_name,
       operation: operation,
       calls: timings.size,
       min: timings.min,
+      median: percentile(sorted, 0.50),
+      p95: percentile(sorted, 0.95),
       max: timings.max,
       average: average
     )
+  end
+
+  def percentile(sorted_timings, ratio)
+    sorted_timings[((sorted_timings.size - 1) * ratio).round]
   end
 
   def database_name


### PR DESCRIPTION
## Summary

- add an automatic unit test for real `sla_get_level` and `sla_get_spent` calculations
- force recalculation rather than timing existing cache reads
- print the database engine, call count, minimum, maximum and average duration
- keep timings informational so machine or CI load cannot make the suite flaky
- document the report in the testing guide

## Validation

The dedicated test passes with 6 assertions and no failures on:

- PostgreSQL 17
- MySQL 8.0
- MariaDB 10.11

Each run uses the same 70 SLA issues and 2 SLA types from the test fixtures.
