### PR TITLE
Restrict cache level filters to authorized projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+-   Restrict SLA level filter options in both cache queries to authorized
+    projects, including global and project-specific views.
+
+------------------------------------------------------------------------
+
 ## 3.0.2 - 2026-09-08
 
 ### Security

--- a/app/models/sla_cache_query.rb
+++ b/app/models/sla_cache_query.rb
@@ -312,7 +312,9 @@ class SlaCacheQuery < Query
     return @all_sla_level_values if @all_sla_level_values
 
     values ||= []
-    SlaLevel.pluck(:name,:id).map { |name,id|
+    scope = SlaLevel.visible
+    scope = scope.in_project(project) if project
+    scope.pluck(:name,:id).map { |name,id|
       values << [name.to_s,id.to_s]
     }
     @all_sla_level_values = values

--- a/app/models/sla_cache_spent_query.rb
+++ b/app/models/sla_cache_spent_query.rb
@@ -189,7 +189,9 @@ class SlaCacheSpentQuery < Query
     return @all_sla_level_values if @all_sla_level_values
 
     values ||= []
-    SlaLevel.pluck(:name,:id).map { |name,id|
+    scope = SlaLevel.visible
+    scope = scope.in_project(project) if project
+    scope.pluck(:name,:id).map { |name,id|
       values << [name.to_s,id.to_s]
     }
     @all_sla_level_values = values

--- a/test/unit/sla_project_visibility_test.rb
+++ b/test/unit/sla_project_visibility_test.rb
@@ -77,4 +77,30 @@ class SlaProjectVisibilityTest < ApplicationSlaUnitsTestCase
                  SlaLevelQuery.new(project: Project.find(2)).all_sla_custom_fields_values
   end
 
+  test "cache level filters respect global and project permissions" do
+    [SlaCacheQuery, SlaCacheSpentQuery].each do |klass|
+      assert_equal [1, 2, 9, 10], klass.new.all_sla_level_values.map { |_, id| id.to_i }.sort
+      assert_equal [1, 2], klass.new(project: Project.find(1)).all_sla_level_values.map { |_, id| id.to_i }.sort
+      assert_empty klass.new(project: Project.find(2)).all_sla_level_values
+    end
+  end
+
+  test "cache level filters do not expose catalogs without SLA permission" do
+    [User.find(5), User.anonymous].each do |user|
+      User.current = user
+      [SlaCacheQuery, SlaCacheSpentQuery].each do |klass|
+        assert_empty klass.new.all_sla_level_values
+        assert_empty klass.new(project: Project.find(1)).all_sla_level_values
+      end
+    end
+  end
+
+  test "administrator cache level filters still respect project context" do
+    User.current = User.find(1)
+    [SlaCacheQuery, SlaCacheSpentQuery].each do |klass|
+      assert_equal (1..10).to_a, klass.new.all_sla_level_values.map { |_, id| id.to_i }.sort
+      assert_equal [1, 2], klass.new(project: Project.find(1)).all_sla_level_values.map { |_, id| id.to_i }.sort
+    end
+  end
+
 end


### PR DESCRIPTION
The SLA level filters on both cache pages exposed names and IDs from unrelated projects. Restrict their options using `SlaLevel.visible` and, when a project is selected, `in_project(project)`.

Add tests for both query classes covering global and project views, forbidden projects, users without SLA permission, anonymous users and administrators. Update the Unreleased changelog.

Validation on PostgreSQL and MariaDB: 930 tests and 4,497 assertions per engine, with zero failures, errors or skips across unit, functional, integration/API/routing, system and documentation suites. PostgreSQL used the Rake suites; MariaDB used separate Ruby test processes on the migrated test database, with test cache IDs reset between subsequent suites for legacy fixtures. `git diff --check` passed.
